### PR TITLE
add condition to allow unknown words to be calculated instead of resulti...

### DIFF
--- a/lib/engine/classifier.rb
+++ b/lib/engine/classifier.rb
@@ -61,6 +61,7 @@ class Classifier
     negative_ratio = negative_count.to_f / negative_total
 
     probability = positive_ratio.to_f / (positive_ratio + negative_ratio)
+    probability = 0 if probability.nan?
 
     ((UNKNOWN_WORD_STRENGTH*UNKNOWN_WORD_PROBABILITY) + (total * probability)) / (UNKNOWN_WORD_STRENGTH+total)
   end

--- a/spec/sentimentalizer_spec.rb
+++ b/spec/sentimentalizer_spec.rb
@@ -4,16 +4,20 @@ describe "Sentimentalizer" do
   before do
     Sentimentalizer.setup
   end
-  
+
   it "will error without a valid input" do
     expect{Sentimentalizer.analyze("")}.to raise_error
   end
-  
+
   it "will return a valid ruby hash with a valid input" do
     Sentimentalizer.analyze("I hate not tests").sentiment.should eq(":(")
   end
-  
+
   it "will return a valid json string with a valid input" do
     JSON.parse(Sentimentalizer.analyze("I hate not tests", true))["sentiment"].should eq(":(")
+  end
+
+  it "will assign a probability of .5 in the case of an unknown word" do
+    Sentimentalizer.analyze("a;lsdnzi").overall_probability.should eq(0.5)
   end
 end


### PR DESCRIPTION
...ng in NaN

combine_probabilities was previously breaking when an unknown word included in the text being analyzed because total_probability was being divided by 0 in calculate_probability. 

I assumed you wanted unknown words to have a probability of 0 because of the constants UNKOWN_WORD_STRENGTH & UNKNOWN_WORD_PROBABILITY. Let me know if this isn't the case, but this solved the issue I was experiencing. 