### PR TITLE
Added :encoding UTF-8 to IO.foreach

### DIFF
--- a/lib/engine/corpus.rb
+++ b/lib/engine/corpus.rb
@@ -18,7 +18,7 @@ class Corpus
 
   def load_from_directory directory
     Dir.glob("#{directory}/*.txt") do |entry|
-      IO.foreach(entry) do |line|
+      IO.foreach(entry, encoding: 'UTF-8') do |line|
         add Document.new(line)
       end
     end

--- a/lib/engine/corpus.rb
+++ b/lib/engine/corpus.rb
@@ -18,7 +18,7 @@ class Corpus
 
   def load_from_directory directory
     Dir.glob("#{directory}/*.txt") do |entry|
-      IO.foreach(entry, encoding: 'UTF-8') do |line|
+      IO.foreach(entry, encoding: Encoding::UTF_8) do |line|
         add Document.new(line)
       end
     end


### PR DESCRIPTION
There is a hidden assumption in the code that assumes that the the training data is UTF-8.

When I run Sentimentalizer as a child process of java, then the process has no "LC_CTYPE=UTF-8" in the environment, so the setup code doesn't work.

I have made the UTF-8 encoding assumption explicit.


Great library.