### PR TITLE
differentiate rails/vanilla ruby use in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Sentimentalizer.analyze('message or tweet or status')
 Sentimentalizer.analyze('message or tweet or status', true)
 ```
 
-4. You will get output like this 
+You will get output like this 
 ```ruby
 Sentimentalizer.analyze('i am so happy')
 => {'text' => 'i am so happy', 'probability' => '0.937', 'sentiment' => ':)' }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This gem can be used separately or integrated with rails app.
 
 # Codeclimate [![Code Climate](https://codeclimate.com/github/malavbhavsar/sentimentalizer.png)](https://codeclimate.com/github/malavbhavsar/sentimentalizer)
 
-## Instructions for use
+## Instructions for Rails use
 
 1. Install gem using bundler `gem "sentimentalizer"`
 
@@ -28,6 +28,43 @@ Sentimentalizer.analyze('message or tweet or status', true)
 Sentimentalizer.analyze('i am so happy')
 => {'text' => 'i am so happy', 'probability' => '0.937', 'sentiment' => ':)' }
 Sentimentalizer.analyze('i am so happy', true)
+=> "{\"text\":\"i am so happy\",\"probability\":\"0.937\",\"sentiment\":\":)\"}"
+```
+
+## Instructions for Vanilla Ruby use
+
+1. Install gem using bundler `gem "sentimentalizer"`
+
+2. Either fire up `irb`, or require it in your project with `require 'sentimentalizer'`
+
+3. Now, you need to train the engine in order to use it
+
+```ruby
+require "sentimentalizer"
+
+Sentimentalizer.setup
+
+# or, wrap it in a class so setup can be automatic
+class Analyzer
+  def initialize
+    Sentimentalizer.setup
+  end
+  
+  def process(phrase)
+    Sentimentalyzer.analyze phrase
+  end
+end
+
+# or for json output
+Sentimentalizer.analyze('message or tweet or status', true)
+```
+
+And now you will get output like this 
+```ruby
+analyzer = Analyzer.new
+analyzer.process('i am so happy')
+=> {'text' => 'i am so happy', 'probability' => '0.937', 'sentiment' => ':)' }
+analyzer.process('i am so happy', true)
 => "{\"text\":\"i am so happy\",\"probability\":\"0.937\",\"sentiment\":\":)\"}"
 ```
 


### PR DESCRIPTION
This is a relatively basic change to the README. After seeing another issue that had been closed with regard to the need to call setup, I thought it would be nice to have a section in the docs that shows how to do things outside of the confines of Rails. If you've any stylistic changes you are after, or anything else feel free to let me know :)

:v: :metal: